### PR TITLE
Add caution about handlers & import to Pitfalls

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_reuse.rst
+++ b/docs/docsite/rst/user_guide/playbooks_reuse.rst
@@ -63,6 +63,7 @@ Using ``import*`` can also have some limitations when compared to dynamic includ
 
 * As noted above, loops cannot be used with imports at all.
 * When using variables for the target file or role name, variables from inventory sources (host/group vars, etc.) cannot be used.
+* Handlers using ``import*`` will not be triggered when notified via their name, as importing overwrites the handler's named task with the imported task list.
 
 .. note::
     Regarding the use of ``notify`` for dynamic tasks: it is still possible to trigger the dynamic include itself, which would result in all tasks within the include being run.


### PR DESCRIPTION
##### SUMMARY
Added a note about handlers not working with import_tasks to the Pitfalls section. The fact that handlers lose their name: when using import_tasks: is entirely consistent with how import_tasks works, but in the case of handlers the result is rather un-intuitive. See e.g. #59706.

##### ISSUE TYPE
- Docs Pull Request